### PR TITLE
Add configuration support

### DIFF
--- a/lib/defra_ruby/address.rb
+++ b/lib/defra_ruby/address.rb
@@ -1,6 +1,20 @@
 # frozen_string_literal: true
 
+require_relative "address/configuration"
+
 module DefraRuby
   module Address
+    class << self
+      # attr_accessor :configuration
+
+      def configure
+        yield(configuration)
+      end
+
+      def configuration
+        @configuration ||= Configuration.new
+        @configuration
+      end
+    end
   end
 end

--- a/lib/defra_ruby/address/configuration.rb
+++ b/lib/defra_ruby/address/configuration.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module DefraRuby
+  module Address
+    class Configuration
+      attr_accessor :host
+
+      def initialize
+        @timeout = nil
+      end
+    end
+  end
+end

--- a/spec/defra_ruby/address/configuration_spec.rb
+++ b/spec/defra_ruby/address/configuration_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module DefraRuby
+  module Address
+    RSpec.describe Configuration do
+      it "sets the appropriate default config settings" do
+        fresh_config = described_class.new
+
+        expect(fresh_config.host).to be_nil
+      end
+    end
+  end
+end

--- a/spec/defra_ruby/address_spec.rb
+++ b/spec/defra_ruby/address_spec.rb
@@ -9,4 +9,22 @@ RSpec.describe DefraRuby::Address do
       expect(DefraRuby::Address::VERSION).to match(/\d+\.\d+\.\d+/)
     end
   end
+
+  describe "#configuration" do
+    context "when the host app has not provided configuration" do
+      it "returns a DefraRuby::Address::Configuration instance" do
+        expect(described_class.configuration).to be_an_instance_of(DefraRuby::Address::Configuration)
+      end
+    end
+
+    context "when the host app has provided configuration" do
+      let(:host) { "http://localhost:9012" }
+
+      it "returns an DefraRuby::Address::Configuration instance with a matching host" do
+        described_class.configure { |config| config.host = host }
+
+        expect(described_class.configuration.host).to eq(host)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Projects that use this gem will always need to specify the host url for the address lookup, irrespective of which of the lookups we're using.

So this change adds support for configuration, specifically the ability to tell the gem what host url to make requests to.