### PR TITLE
Add Response object

### DIFF
--- a/lib/defra_ruby/address.rb
+++ b/lib/defra_ruby/address.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "address/configuration"
+require_relative "address/response"
 
 module DefraRuby
   module Address

--- a/lib/defra_ruby/address/response.rb
+++ b/lib/defra_ruby/address/response.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module DefraRuby
+  module Address
+    class Response
+      attr_reader :error
+      attr_reader :results
+
+      def initialize(response_exe)
+        @success = true
+        @results = []
+        @error = nil
+
+        capture_response(response_exe)
+      end
+
+      def successful?
+        success
+      end
+
+      private
+
+      attr_reader :success
+
+      def capture_response(response_exe)
+        @results = response_exe.call
+      rescue StandardError => e
+        @error = e
+        @success = false
+      end
+    end
+  end
+end

--- a/spec/defra_ruby/address/response_spec.rb
+++ b/spec/defra_ruby/address/response_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module DefraRuby
+  module Address
+    RSpec.describe Response do
+      subject(:response) { described_class.new(response_exe) }
+
+      let(:successful) { -> { [{ "postcode" => "BS1 5AH" }] } }
+      let(:errored) { -> { raise "Boom!" } }
+
+      describe "#successful?" do
+        context "when the response throws an error" do
+          let(:response_exe) { errored }
+
+          it "returns false" do
+            expect(response).to_not be_successful
+          end
+        end
+
+        context "when the response doesn't throw an error" do
+          let(:response_exe) { successful }
+
+          it "returns true" do
+            expect(response).to be_successful
+          end
+        end
+      end
+
+      describe "#results" do
+        context "when the response throws an error" do
+          let(:response_exe) { errored }
+
+          it "returns an empty array" do
+            expect(response.results).to eq([])
+          end
+        end
+
+        context "when the response does not throw an error" do
+          let(:response_exe) { successful }
+
+          it "returns a JSON array" do
+            expect(response.results).to be_instance_of(Array)
+            expect(response.results[0]).to be_instance_of(Hash)
+            expect(response.results[0]["postcode"]).to eq("BS1 5AH")
+          end
+        end
+      end
+
+      describe "#error" do
+        context "when the response throws an error" do
+          let(:response_exe) { errored }
+
+          it "returns the error" do
+            expect(response.error).to be_a(StandardError)
+          end
+        end
+
+        context "when the response don't throw an error" do
+          let(:response_exe) { successful }
+
+          it "returns a nil object" do
+            expect(response.error).to be_nil
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Irrespective of what address lookup is used, the intention is that all callers will receive the same instance type of `Response` with its set API of `successful?`, `results` and `error`.

`Response.results` will also always be an array of JSON hashes, however the format of each will be dependent on which address lookup is used (once we implement it).

It will then be up to the calling app to use the data as it needs.