### PR TITLE
Fix timeout configuration

### DIFF
--- a/lib/defra_ruby/address/configuration.rb
+++ b/lib/defra_ruby/address/configuration.rb
@@ -3,10 +3,10 @@
 module DefraRuby
   module Address
     class Configuration
-      attr_accessor :host
+      attr_accessor :timeout, :host
 
       def initialize
-        @timeout = nil
+        @timeout = 3
       end
     end
   end

--- a/spec/defra_ruby/address/configuration_spec.rb
+++ b/spec/defra_ruby/address/configuration_spec.rb
@@ -8,6 +8,7 @@ module DefraRuby
       it "sets the appropriate default config settings" do
         fresh_config = described_class.new
 
+        expect(fresh_config.timeout).to eq(3)
         expect(fresh_config.host).to be_nil
       end
     end


### PR DESCRIPTION
Clearly bodged something in the copy & paste from [defra-ruby-area](https://github.com/DEFRA/defra-ruby-area) for the configuration.

We want the option to set and override the timeout for requests in this gem as well, so this fix sorts out the timeout config value.