### PR TITLE
Add Addressbase facade version 1 service

### DIFF
--- a/lib/defra_ruby/address.rb
+++ b/lib/defra_ruby/address.rb
@@ -5,6 +5,7 @@ require_relative "address/no_match_error"
 require_relative "address/response"
 
 require_relative "address/services/base_service"
+require_relative "address/services/ea_address_facade_v1_service"
 require_relative "address/services/os_places_address_lookup_service"
 
 module DefraRuby

--- a/lib/defra_ruby/address/configuration.rb
+++ b/lib/defra_ruby/address/configuration.rb
@@ -3,10 +3,12 @@
 module DefraRuby
   module Address
     class Configuration
-      attr_accessor :timeout, :host
+      attr_accessor :timeout, :host, :client_id, :key
 
       def initialize
         @timeout = 3
+        @client_id = 0
+        @key = "client1"
       end
     end
   end

--- a/lib/defra_ruby/address/services/ea_address_facade_v1_service.rb
+++ b/lib/defra_ruby/address/services/ea_address_facade_v1_service.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module DefraRuby
+  module Address
+    class EaAddressFacadeV1Service < BaseService
+
+      def run(postcode)
+        @postcode = postcode
+        Response.new(response_exe)
+      end
+
+      private
+
+      attr_reader :postcode
+
+      def url
+        host = DefraRuby::Address.configuration.host
+        client_id = DefraRuby::Address.configuration.client_id
+        key = DefraRuby::Address.configuration.key
+
+        File.join(
+          host,
+          "/address-service/v1/addresses/",
+          "postcode?client-id=#{client_id}&key=#{key}&postcode=#{postcode}"
+        )
+      end
+
+      def response_exe
+        lambda do
+          response = RestClient::Request.execute(
+            method: :get,
+            url: url,
+            timeout: DefraRuby::Address.configuration.timeout
+          )
+          results = JSON.parse(response)["results"]
+
+          raise DefraRuby::Address::NoMatchError if results.empty?
+
+          results
+        end
+      end
+
+    end
+  end
+end

--- a/spec/defra_ruby/address/configuration_spec.rb
+++ b/spec/defra_ruby/address/configuration_spec.rb
@@ -10,6 +10,8 @@ module DefraRuby
 
         expect(fresh_config.timeout).to eq(3)
         expect(fresh_config.host).to be_nil
+        expect(fresh_config.client_id).to eq(0)
+        expect(fresh_config.key).to eq("client1")
       end
     end
   end

--- a/spec/defra_ruby/address/services/ea_address_facade_v1_service_spec.rb
+++ b/spec/defra_ruby/address/services/ea_address_facade_v1_service_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module DefraRuby
+  module Address
+    RSpec.describe EaAddressFacadeV1Service do
+      describe "#run" do
+        before do
+          DefraRuby::Address.configure { |c| c.host = "http://localhost:8005/" }
+          stub_request(:get, url).to_return(status: code, body: body)
+        end
+
+        let(:client_id) { DefraRuby::Address.configuration.client_id }
+        let(:key) { DefraRuby::Address.configuration.key }
+        let(:postcode) { "BS1 5AH" }
+        let(:url) { "http://localhost:8005/address-service/v1/addresses/postcode?client-id=#{client_id}&key=#{key}&postcode=#{postcode}" }
+        let(:code) { 200 }
+        let(:body) { File.read("spec/fixtures/ea_address_facade_v1_valid.json") }
+
+        include_examples "handle request errors"
+
+        context "when the postcode is valid" do
+
+          it "returns a successful response" do
+            response = described_class.run(postcode)
+
+            expect(a_request(:get, url)).to have_been_made.at_most_once
+
+            expect(response).to be_a(Response)
+            expect(response.successful?).to eq(true)
+            expect(response.results).not_to be_empty
+          end
+        end
+
+        context "when the postcode is invalid" do
+          context "because it is not found" do
+            let(:postcode) { "BS1 9XX" }
+            let(:body) { File.read("spec/fixtures/ea_address_facade_v1_not_found.json") }
+
+            it "returns a 'NoMatchError'" do
+              response = described_class.run(postcode)
+
+              expect(a_request(:get, url)).to have_been_made.at_most_once
+
+              expect(response).to be_a(Response)
+              expect(response).to_not be_successful
+              expect(response.results).to be_empty
+              expect(response.error).to be_an_instance_of(DefraRuby::Address::NoMatchError)
+            end
+          end
+
+          context "because it is blank" do
+            let(:postcode) { "" }
+            let(:code) { 400 }
+            let(:body) { File.read("spec/fixtures/ea_address_facade_v1_blank.json") }
+
+            it "returns a failed response" do
+              response = described_class.run(postcode)
+
+              expect(a_request(:get, url)).to have_been_made.at_most_once
+
+              expect(response).to be_a(Response)
+              expect(response).to_not be_successful
+              expect(response.results).to be_empty
+              expect(response.error).to be_an_instance_of(RestClient::BadRequest)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/defra_ruby/address/services/os_places_address_lookup_service_spec.rb
+++ b/spec/defra_ruby/address/services/os_places_address_lookup_service_spec.rb
@@ -14,32 +14,7 @@ module DefraRuby
         let(:postcode) { "BS1 5AH" }
         let(:url) { "http://localhost:8005/addresses?postcode=#{postcode}" }
         let(:code) { 200 }
-        let(:body) do
-          [{
-            "moniker" => "340116",
-            "uprn" => "340116",
-            "lines" => ["NATURAL ENGLAND", "DEANERY ROAD"],
-            "town" => "BRISTOL",
-            "postcode" => "BS1 5AH",
-            "easting" => "358205",
-            "northing" => "172708",
-            "country" => "",
-            "dependentLocality" => "",
-            "dependentThroughfare" => "",
-            "administrativeArea" => "BRISTOL",
-            "localAuthorityUpdateDate" => "",
-            "royalMailUpdateDate" => "",
-            "partial" => "NATURAL ENGLAND, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH",
-            "subBuildingName" => "",
-            "buildingName" => "HORIZON HOUSE",
-            "thoroughfareName" => "DEANERY ROAD",
-            "organisationName" => "NATURAL ENGLAND",
-            "buildingNumber" => "",
-            "postOfficeBoxNumber" => "",
-            "departmentName" => "",
-            "doubleDependentLocality" => ""
-          }].to_json
-        end
+        let(:body) { File.read("spec/fixtures/os_places_address_lookup_valid.json") }
 
         include_examples "handle request errors"
 
@@ -61,7 +36,7 @@ module DefraRuby
 
           context "because it is not found" do
             let(:postcode) { "BS1 9XX" }
-            let(:body) { '{"error":{"statuscode":400,"message":"Parameters are not valid"}}' }
+            let(:body) { File.read("spec/fixtures/os_places_address_lookup_not_found.json") }
 
             it "returns a 'NoMatchError'" do
               response = described_class.run(postcode)
@@ -77,7 +52,7 @@ module DefraRuby
 
           context "because it is blank" do
             let(:postcode) { "" }
-            let(:body) { '{"errors":["query param postcode may not be empty"]}' }
+            let(:body) { File.read("spec/fixtures/os_places_address_lookup_blank.json") }
 
             it "returns a failed response" do
               response = described_class.run(postcode)

--- a/spec/fixtures/ea_address_facade_v1_blank.json
+++ b/spec/fixtures/ea_address_facade_v1_blank.json
@@ -1,0 +1,13 @@
+{
+  "facade_status_code": 400,
+  "facade_error_message": "bad request to supplier service",
+  "facade_error_code": "address_service_error_1",
+  "supplier_was_called": true,
+  "supplier_status_code": 400,
+  "supplier_response": {
+    "error": {
+      "statuscode": 400,
+      "message": "Parameter postcode cannot be empty."
+    }
+  }
+}

--- a/spec/fixtures/ea_address_facade_v1_not_found.json
+++ b/spec/fixtures/ea_address_facade_v1_not_found.json
@@ -1,0 +1,8 @@
+{
+  "totalMatches": 0,
+  "startMatch": null,
+  "endMatch": null,
+  "uri_to_supplier": "https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?lr=EN&postcode=bs19xx&maxresults=100&dataset=DPA",
+  "uri_from_client": "stub",
+  "results": []
+}

--- a/spec/fixtures/ea_address_facade_v1_valid.json
+++ b/spec/fixtures/ea_address_facade_v1_valid.json
@@ -1,0 +1,45 @@
+{
+  "totalMatches": 2,
+  "startMatch": 1,
+  "endMatch": 2,
+  "uri_to_supplier": "https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode?lr=EN&postcode=bs15ah&maxresults=100&dataset=DPA",
+  "uri_from_client": "stub",
+  "results": [
+    {
+      "uprn": 340116,
+      "address": "ENVIRONMENT AGENCY, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH",
+      "organisation": "ENVIRONMENT AGENCY",
+      "premises": "HORIZON HOUSE",
+      "street_address": "DEANERY ROAD",
+      "locality": null,
+      "city": "BRISTOL",
+      "postcode": "BS1 5AH",
+      "x": "358205.03",
+      "y": "172708.07",
+      "coordinate_system": null,
+      "state_date": "12/10/2009",
+      "blpu_state_code": null,
+      "postal_address_code": null,
+      "logical_status_code": null,
+      "source_data_type": "dpa"
+    },
+    {
+      "uprn": 340117,
+      "address": "THRIVE RENEWABLES PLC, DEANERY ROAD, BRISTOL, BS1 5AH",
+      "organisation": "THRIVE RENEWABLES PLC",
+      "premises": null,
+      "street_address": "DEANERY ROAD",
+      "locality": null,
+      "city": "BRISTOL",
+      "postcode": "BS1 5AH",
+      "x": "358130.1",
+      "y": "172687.87",
+      "coordinate_system": null,
+      "state_date": "12/10/2009",
+      "blpu_state_code": null,
+      "postal_address_code": null,
+      "logical_status_code": null,
+      "source_data_type": "dpa"
+    }
+  ]
+}

--- a/spec/fixtures/os_places_address_lookup_blank.json
+++ b/spec/fixtures/os_places_address_lookup_blank.json
@@ -1,0 +1,5 @@
+{
+  "errors": [
+    "query param postcode may not be empty"
+  ]
+}

--- a/spec/fixtures/os_places_address_lookup_not_found.json
+++ b/spec/fixtures/os_places_address_lookup_not_found.json
@@ -1,0 +1,6 @@
+{
+  "error": {
+    "statuscode": 400,
+    "message": "Parameters are not valid"
+  }
+}

--- a/spec/fixtures/os_places_address_lookup_valid.json
+++ b/spec/fixtures/os_places_address_lookup_valid.json
@@ -1,0 +1,56 @@
+[
+  {
+    "moniker": "340116",
+    "uprn": "340116",
+    "lines": [
+      "ENVIRONMENT AGENCY",
+      "DEANERY ROAD"
+    ],
+    "town": "BRISTOL",
+    "postcode": "BS1 5AH",
+    "easting": "358205",
+    "northing": "172708",
+    "country": "",
+    "dependentLocality": "",
+    "dependentThroughfare": "",
+    "administrativeArea": "BRISTOL",
+    "localAuthorityUpdateDate": "",
+    "royalMailUpdateDate": "",
+    "partial": "ENVIRONMENT AGENCY, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH",
+    "subBuildingName": "",
+    "buildingName": "HORIZON HOUSE",
+    "thoroughfareName": "DEANERY ROAD",
+    "organisationName": "ENVIRONMENT AGENCY",
+    "buildingNumber": "",
+    "postOfficeBoxNumber": "",
+    "departmentName": "",
+    "doubleDependentLocality": ""
+  },
+  {
+    "moniker": "340117",
+    "uprn": "340117",
+    "lines": [
+      "THRIVE RENEWABLES PLC",
+      "DEANERY ROAD"
+    ],
+    "town": "BRISTOL",
+    "postcode": "BS1 5AH",
+    "easting": "358130",
+    "northing": "172687",
+    "country": "",
+    "dependentLocality": "",
+    "dependentThroughfare": "",
+    "administrativeArea": "BRISTOL",
+    "localAuthorityUpdateDate": "",
+    "royalMailUpdateDate": "",
+    "partial": "THRIVE RENEWABLES PLC, DEANERY ROAD, BRISTOL, BS1 5AH",
+    "subBuildingName": "",
+    "buildingName": "",
+    "thoroughfareName": "DEANERY ROAD",
+    "organisationName": "THRIVE RENEWABLES PLC",
+    "buildingNumber": "",
+    "postOfficeBoxNumber": "",
+    "departmentName": "",
+    "doubleDependentLocality": ""
+  }
+]


### PR DESCRIPTION
The [EA Address Facade Service](https://github.com/DEFRA/ea-address-facade) comes in 2 flavours; version 1 and 1.1.

The first digital services to use it like [Waste Exemptions](https://github.com/DEFRA/ruby-services-team/tree/master/services/wex) and [Flood Risk Activity Exemptions](https://github.com/DEFRA/ruby-services-team/tree/master/services/frae) are on version 1.

So to support them this change adds a new service to the gem that works with version 1 of the facade's API.