### PR TITLE
Fix rubocop cop rename issue

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -11,7 +11,7 @@ Bundler::GemHelper.install_tasks
 # This is wrapped to prevent an error when rake is called in environments where
 # rspec may not be available, e.g. production. As such we don't need to handle
 # the error.
-# rubocop:disable Lint/HandleExceptions
+# rubocop:disable Lint/SuppressedException
 begin
   require "rspec/core/rake_task"
 
@@ -32,4 +32,4 @@ begin
 rescue LoadError
   # no changelog available
 end
-# rubocop:enable Lint/HandleExceptions
+# rubocop:enable Lint/SuppressedException


### PR DESCRIPTION
We spotted that automated builds on master by Travis-CI had started failing.

The issue is that rubocop has released a new version (0.77) and it looks like it has changed the name of the cop which checks suppressed exceptions.

We suppress them because they are environment specific. We don't want the `Rakefile` to fail if the environment is set to production, just because we reference development only libraries in it.